### PR TITLE
Possible bugs in evaluate_generation.py

### DIFF
--- a/src/evaluate_generation.py
+++ b/src/evaluate_generation.py
@@ -126,9 +126,8 @@ class GPTEvaluator:
                 messages=chat,
                 max_tokens=20
             )
-            output.append(response.choices[0].message)
-        self.post_process(output)
-        return output
+            output.append(response.choices[0].message.content)
+        return self.post_process(output)
     
     def evaluate_batch(self, list_of_sentences):
         list_of_chat = self.transform(list_of_sentences)


### PR DESCRIPTION
Line 129: the output list expects strings but looks like there was an API change on the OpenAI side, which changed the type of `response.choices[0].message` from string to a wrapper `ChatCompletionMessage`. I think we should add `.content` to extract the message from the wrapper class.

Line 131: I think the function should return the post-processed output instead of the raw output?